### PR TITLE
Add alphaPhi to correctFluxes in multiphase/interDyMFoam/ras/damBreakWithObstacle tutorial

### DIFF
--- a/tutorials/multiphase/interDyMFoam/ras/damBreakWithObstacle/constant/dynamicMeshDict
+++ b/tutorials/multiphase/interDyMFoam/ras/damBreakWithObstacle/constant/dynamicMeshDict
@@ -42,6 +42,7 @@ dynamicRefineFvMeshCoeffs
         (phi none)
         (nHatf none)
         (rhoPhi none)
+        (alphaPhi none)
         (ghf none)
     );
     // Write the refinement level as a volScalarField


### PR DESCRIPTION
This change has already been made in OpenFOAM-dev, but has not made its way to v3.0.x
https://github.com/OpenFOAM/OpenFOAM-dev/commit/449a9ecc08e4ad12ae64fc5f93b756263357566c
